### PR TITLE
clone indexes only when required

### DIFF
--- a/pg_rollingwindow.py
+++ b/pg_rollingwindow.py
@@ -704,7 +704,7 @@ RETURNING relid,
                 try:
                     cursor.execute('SELECT rolling_window.move_data_to_partition(%(schema)s, %(table)s, %(lower_bound)s, %(clone_indexes)s, %(to_limbo)s)',
                                    {'schema': self.schema, 'table': self.table, 'lower_bound': lower_bound,
-                                    'clone_indexes': True, 'to_limbo': False})
+                                    'clone_indexes': False, 'to_limbo': False})
                     rows_moved = cursor.fetchone()[0]
                     l.info('Moved %s rows to partition %s.', rows_moved, partition)
                 except IntegrityError, e:

--- a/test_pg_rollingwindow.py
+++ b/test_pg_rollingwindow.py
@@ -320,7 +320,7 @@ RETURNING relid,
         n += 1
         self.assertEqual('execute', method_calls[n][0])    # move_data_to_partition
         self.assertEqual(('SELECT rolling_window.move_data_to_partition(%(schema)s, %(table)s, %(lower_bound)s, %(clone_indexes)s, %(to_limbo)s)',
-                        {'clone_indexes': True, 'lower_bound': 30, 'schema': 'fake_schema', 'table': 'fake_table', 'to_limbo': False}),
+                        {'clone_indexes': False, 'lower_bound': 30, 'schema': 'fake_schema', 'table': 'fake_table', 'to_limbo': False}),
                         method_calls[n][1])
         n += 1
         self.assertEqual('fetchone', method_calls[n][0])


### PR DESCRIPTION
Rather than attempting to clone indexes every time we move data to a
partition, we will clone indexes only on creation of a partition
(following the first move of data to that partition).

This makes pg_rollingwindows less self-healing but avoids taking the
really obnoxious AccessExclusiveLock.
